### PR TITLE
Encoder type checking

### DIFF
--- a/dist/lamden.js
+++ b/dist/lamden.js
@@ -2394,15 +2394,8 @@ class LamdenMasterNode_API{
     constructor(networkInfoObj){
         if (!validateTypes.isObjectWithKeys(networkInfoObj)) throw new Error(`Expected Object and got Type: ${typeof networkInfoObj}`)
         if (!validateTypes.isArrayWithValues(networkInfoObj.hosts)) throw new Error(`HOSTS Required (Type: Array)`)
-        if (!validateTypes.isStringWithValue(networkInfoObj.type)) throw new Error(`Network Type Required (Type: String)`)
 
-        const lamdenNetworkTypes = ['mockchain', 'testnet', 'mainnet'];
-        this.hosts = this.validateHosts(networkInfoObj.hosts);
-        this.networkType = networkInfoObj.type.toLowerCase();
-        if (!lamdenNetworkTypes.includes(this.networkType)) {
-            throw new Error(`${this.networkType} not in Lamden Network Types: ${JSON.stringify(lamdenNetworkTypes)}`)
-        }
-        
+        this.hosts = this.validateHosts(networkInfoObj.hosts);        
     }
     //This will throw an error if the protocol wasn't included in the host string
     vaidateProtocol(host){
@@ -2511,31 +2504,7 @@ class LamdenMasterNode_API{
             return false;
         })
     }
-    /* 
-    // Mockchain Depreciated
-    ///
-    async mintTestNetCoins(vk, amount){
-        if (this.networkType !== 'mockchain') throw Error (`${this.networkType} does not allow minting of coins`)
-        if (!validateTypes.isStringWithValue(vk) || !validateTypes.isNumber(amount)) return false;
-        let data = JSON.stringify({vk, amount})
 
-        let path = `/mint/`
-        return this.send('POST', path, data, (res, err) => {
-            try{
-                if (res.success) return true;
-            } catch (e){}
-            return false;
-        })    
-    }
-
-    async lintCode(name, code){
-        let data = JSON.stringify({name, code})
-        return this.send('POST', '/lint/', data, (res, err) => {
-            if (err) return err;
-            return res;
-        })
-    }
-    */
     async sendTransaction(data, callback){
         return this.send('POST', '/', JSON.stringify(data), (res, err) => {
             if (err){
@@ -2598,16 +2567,14 @@ class Network {
     //
     // networkInfo: {
     //      hosts: <array> list of masternode hostname/ip urls,
-    //      type: <string> "testnet", "mainnet" or "mockchain"
+    //      type: <string> "testnet", "mainnet" or "custom"
     //  },
     constructor(networkInfoObj){
-        const lamdenNetworkTypes = ['mockchain', 'testnet', 'mainnet'];
         //Reject undefined or missing info
         if (!validateTypes$1.isObjectWithKeys(networkInfoObj)) throw new Error(`Expected Network Info Object and got Type: ${typeof networkInfoObj}`)
         if (!validateTypes$1.isArrayWithValues(networkInfoObj.hosts)) throw new Error(`HOSTS Required (Type: Array)`)
-        if (!validateTypes$1.isStringWithValue(networkInfoObj.type)) throw new Error(`Network Type Required (Type: String)`)
 
-        this.type = networkInfoObj.type.toLowerCase();
+        this.type = validateTypes$1.isStringWithValue(networkInfoObj.type) ? networkInfoObj.type.toLowerCase() : "custom";
         this.events = new EventEmitter();
         this.hosts = this.validateHosts(networkInfoObj.hosts);
         this.currencySymbol = validateTypes$1.isStringWithValue(networkInfoObj.currencySymbol) ? networkInfoObj.currencySymbol : 'TAU';
@@ -2621,15 +2588,6 @@ class Network {
         } catch (e) {
             throw new Error(e)
         }
-        
-        if (!lamdenNetworkTypes.includes(this.type)) {
-            throw new Error(`${this.type} not in Lamden Network Types: ${JSON.stringify(lamdenNetworkTypes)}`)
-        }
-        
-        this.mainnet = this.type === 'mainnet';
-        this.testnet = this.type === 'testnet';
-        this.mockchain = this.type === 'mockchain';
-
     }
     //This will throw an error if the protocol wasn't included in the host string
     vaidateProtocol(host){
@@ -2659,9 +2617,6 @@ class Network {
             hosts: this.hosts,
             url: this.url,
             online: this.online,
-            mainnet: this.mainnet,
-            testnet: this.testnet,
-            mockchain: this.mockchain
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lamden-js",
-  "version": "1.8.5",
+  "version": "1.8.6",
   "description": "A javascript implementaion for creating wallets, submitting transactions and interacting with masternodes on the Lamden Blockchain.",
   "main": "dist/lamden.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lamden-js",
-  "version": "1.8.6",
+  "version": "1.9.0",
   "description": "A javascript implementaion for creating wallets, submitting transactions and interacting with masternodes on the Lamden Blockchain.",
   "main": "dist/lamden.js",
   "scripts": {

--- a/src/js/masternode-api.js
+++ b/src/js/masternode-api.js
@@ -6,15 +6,8 @@ export class LamdenMasterNode_API{
     constructor(networkInfoObj){
         if (!validateTypes.isObjectWithKeys(networkInfoObj)) throw new Error(`Expected Object and got Type: ${typeof networkInfoObj}`)
         if (!validateTypes.isArrayWithValues(networkInfoObj.hosts)) throw new Error(`HOSTS Required (Type: Array)`)
-        if (!validateTypes.isStringWithValue(networkInfoObj.type)) throw new Error(`Network Type Required (Type: String)`)
 
-        const lamdenNetworkTypes = ['mockchain', 'testnet', 'mainnet']
-        this.hosts = this.validateHosts(networkInfoObj.hosts);
-        this.networkType = networkInfoObj.type.toLowerCase();
-        if (!lamdenNetworkTypes.includes(this.networkType)) {
-            throw new Error(`${this.networkType} not in Lamden Network Types: ${JSON.stringify(lamdenNetworkTypes)}`)
-        }
-        
+        this.hosts = this.validateHosts(networkInfoObj.hosts);        
     }
     //This will throw an error if the protocol wasn't included in the host string
     vaidateProtocol(host){
@@ -123,31 +116,7 @@ export class LamdenMasterNode_API{
             return false;
         })
     }
-    /* 
-    // Mockchain Depreciated
-    ///
-    async mintTestNetCoins(vk, amount){
-        if (this.networkType !== 'mockchain') throw Error (`${this.networkType} does not allow minting of coins`)
-        if (!validateTypes.isStringWithValue(vk) || !validateTypes.isNumber(amount)) return false;
-        let data = JSON.stringify({vk, amount})
 
-        let path = `/mint/`
-        return this.send('POST', path, data, (res, err) => {
-            try{
-                if (res.success) return true;
-            } catch (e){}
-            return false;
-        })    
-    }
-
-    async lintCode(name, code){
-        let data = JSON.stringify({name, code})
-        return this.send('POST', '/lint/', data, (res, err) => {
-            if (err) return err;
-            return res;
-        })
-    }
-    */
     async sendTransaction(data, callback){
         return this.send('POST', '/', JSON.stringify(data), (res, err) => {
             if (err){

--- a/src/js/network.js
+++ b/src/js/network.js
@@ -8,16 +8,14 @@ export class Network {
     //
     // networkInfo: {
     //      hosts: <array> list of masternode hostname/ip urls,
-    //      type: <string> "testnet", "mainnet" or "mockchain"
+    //      type: <string> "testnet", "mainnet" or "custom"
     //  },
     constructor(networkInfoObj){
-        const lamdenNetworkTypes = ['mockchain', 'testnet', 'mainnet']
         //Reject undefined or missing info
         if (!validateTypes.isObjectWithKeys(networkInfoObj)) throw new Error(`Expected Network Info Object and got Type: ${typeof networkInfoObj}`)
         if (!validateTypes.isArrayWithValues(networkInfoObj.hosts)) throw new Error(`HOSTS Required (Type: Array)`)
-        if (!validateTypes.isStringWithValue(networkInfoObj.type)) throw new Error(`Network Type Required (Type: String)`)
 
-        this.type = networkInfoObj.type.toLowerCase();
+        this.type = validateTypes.isStringWithValue(networkInfoObj.type) ? networkInfoObj.type.toLowerCase() : "custom";
         this.events = new EventEmitter()
         this.hosts = this.validateHosts(networkInfoObj.hosts);
         this.currencySymbol = validateTypes.isStringWithValue(networkInfoObj.currencySymbol) ? networkInfoObj.currencySymbol : 'TAU'
@@ -31,15 +29,6 @@ export class Network {
         } catch (e) {
             throw new Error(e)
         }
-        
-        if (!lamdenNetworkTypes.includes(this.type)) {
-            throw new Error(`${this.type} not in Lamden Network Types: ${JSON.stringify(lamdenNetworkTypes)}`)
-        }
-        
-        this.mainnet = this.type === 'mainnet'
-        this.testnet = this.type === 'testnet'
-        this.mockchain = this.type === 'mockchain'
-
     }
     //This will throw an error if the protocol wasn't included in the host string
     vaidateProtocol(host){
@@ -69,9 +58,6 @@ export class Network {
             hosts: this.hosts,
             url: this.url,
             online: this.online,
-            mainnet: this.mainnet,
-            testnet: this.testnet,
-            mockchain: this.mockchain
         }
     }
 }

--- a/test/masternode_api-test.js
+++ b/test/masternode_api-test.js
@@ -33,7 +33,6 @@ describe('Test Masternode API returns', () => {
             let api = new Masternode_API(goodNetwork)
             expect(api).to.exist;
             expect(JSON.stringify(api.hosts)).to.be(JSON.stringify(goodNetwork.hosts));
-            expect(api.type).to.be(goodNetwork.networkType);
             expect(api.url).to.be(goodNetwork.hosts[0]);
         })
         it('rejects arg not being an object', () => {
@@ -61,24 +60,6 @@ describe('Test Masternode API returns', () => {
                 new Masternode_API(networkInfo)
             } catch (e) {error = e}
             expect(error.message).to.be('Host String must include http:// or https://')
-        })
-        it('rejects missing type string', () => {
-            let error;
-            try{
-                let networkInfo = copyObject(goodNetwork)
-                networkInfo.type = ''
-                new Masternode_API(networkInfo)
-            } catch (e) {error = e}
-            expect(error.message).to.be('Network Type Required (Type: String)')
-        })
-        it('rejects invalid type string', () => {
-            let error;
-            try{
-                let networkInfo = copyObject(goodNetwork)
-                networkInfo.type = 'badtype'
-                new Masternode_API(networkInfo)
-            } catch (e) {error = e}
-            expect(error.message).to.be(`badtype not in Lamden Network Types: ["mockchain","testnet","mainnet"]`)
         })
     })
 

--- a/test/network-test.js
+++ b/test/network-test.js
@@ -24,38 +24,9 @@ describe('Test Netowrk class', () => {
             expect(network.type).to.be(goodNetwork.type);
             expect(network.name).to.be(goodNetwork.name);
             expect(network.lamden).to.be(goodNetwork.lamden);
-            expect(network.mainnet).to.be(false);
-            expect(network.testnet).to.be(true);
-            expect(network.mockchain).to.be(false);
             expect(network.blockExplorer).to.be(goodNetwork.blockExplorer);
         }) 
-        it('sets mainnet flag', () => {
-            let networkInfo = copyObject(goodNetwork)
-            networkInfo.type = 'mainnet'
-            let network = new Lamden.Network(networkInfo)
-            expect(network.mainnet).to.be(true);
-            expect(network.testnet).to.be(false);
-            expect(network.mockchain).to.be(false);
 
-        })
-        it('sets testnet flag', () => {
-            let networkInfo = copyObject(goodNetwork)
-            networkInfo.type = 'testnet'
-            let network = new Lamden.Network(networkInfo)
-            expect(network.mainnet).to.be(false);
-            expect(network.testnet).to.be(true);
-            expect(network.mockchain).to.be(false);
-
-        })
-        it('sets mockchain flag', () => {
-            let networkInfo = copyObject(goodNetwork)
-            networkInfo.type = 'mockchain'
-            let network = new Lamden.Network(networkInfo)
-            expect(network.mainnet).to.be(false);
-            expect(network.testnet).to.be(false);
-            expect(network.mockchain).to.be(true);
-
-        })
         it('rejects missing hosts Array', () => {
             let error;
             try{
@@ -75,23 +46,11 @@ describe('Test Netowrk class', () => {
             } catch (e) {error = e}
             expect(error.message).to.be('Host String must include http:// or https://')
         })
-        it('rejects missing type string', () => {
-            let error;
-            try{
-                let networkInfo = copyObject(goodNetwork)
-                networkInfo.type = ''
-                new Lamden.Network(networkInfo)
-            } catch (e) {error = e}
-            expect(error.message).to.be('Network Type Required (Type: String)')
-        })
-        it('rejects invalid type string', () => {
-            let error;
-            try{
-                let networkInfo = copyObject(goodNetwork)
-                networkInfo.type = 'badtype'
-                new Lamden.Network(networkInfo)
-            } catch (e) {error = e}
-            expect(error.message).to.be(`Error: badtype not in Lamden Network Types: ["mockchain","testnet","mainnet"]`)
+        it('defaults missing type to custom', () => {
+            let networkInfo = copyObject(goodNetwork)
+            networkInfo.type = ''
+            let network = new Lamden.Network(networkInfo)
+            expect(network.type).to.be("custom");
         })
         it('rejects arg not being an object', () => {
             let error;


### PR DESCRIPTION
REmoved the need to provide a "network type".  This was used to determine the API routes that could be used, but the API is not the same for any Lamden network.