### PR TITLE
now checks if the masternode result is a string

### DIFF
--- a/dist/lamden.js
+++ b/dist/lamden.js
@@ -5923,20 +5923,29 @@ class TransactionBuilder extends Network {
                 let checkAgain = false;
                 const timestamp =  new Date().toUTCString();
                 if (typeof res === 'undefined'){
-                    this.txCheckResult.error = 'TypeError: Failed to fetch';
+                    res = {};
+                    res.error = 'TypeError: Failed to fetch';
                 }else{
-                    if (res.error){
-                        if (res.error === 'Transaction not found.'){
-                            if (this.txCheckAttempts < this.txCheckLimit){
-                                checkAgain = true;
-                            }else{
-                                this.txCheckResult.errors = [res.error, `Retry Attmpts ${this.txCheckAttempts} hit while checking for Tx Result.`];
-                            }
+                    if (typeof res === 'string') {
+                        if (this.txCheckAttempts < this.txCheckLimit){
+                            checkAgain = true;
                         }else{
-                            this.txCheckResult.errors = [res.error];
+                            this.txCheckResult.errors = [res];
                         }
                     }else{
-                        this.txCheckResult = res;
+                        if (res.error){
+                            if (res.error === 'Transaction not found.'){
+                                if (this.txCheckAttempts < this.txCheckLimit){
+                                    checkAgain = true;
+                                }else{
+                                    this.txCheckResult.errors = [res.error, `Retry Attmpts ${this.txCheckAttempts} hit while checking for Tx Result.`];
+                                }
+                            }else{
+                                this.txCheckResult.errors = [res.error];
+                            }
+                        }else{
+                            this.txCheckResult = res;
+                        }
                     }
                 }
                 if (checkAgain) timerId = setTimeout(checkTx.bind(this), 1000);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "lamden-js",
-  "version": "1.16.0",
+  "version": "1.21.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -748,11 +748,6 @@
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
-    "decimal.js": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.0.tgz",
-      "integrity": "sha512-vDPw+rDgn3bZe1+F/pyEwb1oMG2XTlRVgAa6B4KccTEpYgF8w6eQllVbQcfIJnZyvzFtFpxnpGtx8dd7DJp/Rw=="
-    },
     "deferred-leveldown": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-0.2.0.tgz",
@@ -799,9 +794,9 @@
       }
     },
     "elliptic": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
-      "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+      "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
       "dev": true,
       "requires": {
         "bn.js": "^4.4.0",
@@ -1518,9 +1513,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
       "dev": true
     },
     "log-symbols": {
@@ -1653,9 +1648,9 @@
       }
     },
     "node-fetch": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "normalize-path": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lamden-js",
-  "version": "1.20.6",
+  "version": "1.21.0",
   "description": "A javascript implementaion for creating wallets, submitting transactions and interacting with masternodes on the Lamden Blockchain.",
   "main": "dist/lamden.js",
   "scripts": {
@@ -33,7 +33,7 @@
   "dependencies": {
     "assert": "1.4.1",
     "bignumber.js": "^9.0.0",
-    "node-fetch": "^2.6.0",
+    "node-fetch": "^2.6.1",
     "tweetnacl": "1.0.1",
     "types-validate-assert": "^1.0.1"
   },

--- a/src/js/transactionBuilder.js
+++ b/src/js/transactionBuilder.js
@@ -220,20 +220,29 @@ export class TransactionBuilder extends Network {
                 let checkAgain = false;
                 const timestamp =  new Date().toUTCString();
                 if (typeof res === 'undefined'){
-                    this.txCheckResult.error = 'TypeError: Failed to fetch'
+                    res = {}
+                    res.error = 'TypeError: Failed to fetch'
                 }else{
-                    if (res.error){
-                        if (res.error === 'Transaction not found.'){
-                            if (this.txCheckAttempts < this.txCheckLimit){
-                                checkAgain = true
-                            }else{
-                                this.txCheckResult.errors = [res.error, `Retry Attmpts ${this.txCheckAttempts} hit while checking for Tx Result.`]
-                            }
+                    if (typeof res === 'string') {
+                        if (this.txCheckAttempts < this.txCheckLimit){
+                            checkAgain = true
                         }else{
-                            this.txCheckResult.errors = [res.error]
+                            this.txCheckResult.errors = [res]
                         }
                     }else{
-                        this.txCheckResult = res;
+                        if (res.error){
+                            if (res.error === 'Transaction not found.'){
+                                if (this.txCheckAttempts < this.txCheckLimit){
+                                    checkAgain = true
+                                }else{
+                                    this.txCheckResult.errors = [res.error, `Retry Attmpts ${this.txCheckAttempts} hit while checking for Tx Result.`]
+                                }
+                            }else{
+                                this.txCheckResult.errors = [res.error]
+                            }
+                        }else{
+                            this.txCheckResult = res;
+                        }
                     }
                 }
                 if (checkAgain) timerId = setTimeout(checkTx.bind(this), 1000);

--- a/test/masternode_api-test.js
+++ b/test/masternode_api-test.js
@@ -79,21 +79,18 @@ describe('Test Masternode API returns', () => {
     context('Masternode_API.getCurrencyBalance()', () => {
         it('returns the float balance for a vk', async () => {
             let response = await goodNetwork_api.getCurrencyBalance(balanceCheckWallet.float)
-            expect(response.toNumber()).to.be.above(0);
+            expect(response).to.be.above(0);
         })
         it('returns the int balance for a vk', async () => {
             let response = await goodNetwork_api.getCurrencyBalance(balanceCheckWallet.int)
-            console.log(response)
-            expect(response.toFixed(8)).to.be.above(0);
+            expect(response).to.be.above(0);
         })
         it('returns 0 if the vk does not exist yet', async () => {
             let response = await goodNetwork_api.getCurrencyBalance(wallet.new_wallet().vk)
-            console.log(response)
             expect(response.toNumber()).to.be(0);
         })
         it('returns 0 if provided network is unresponsive',  async () => {
             let response = await badNetwork_api.getCurrencyBalance()
-            console.log(response)
             expect(response.toNumber()).to.be(0);
         })
     })

--- a/test/transactionBatcher-test.js
+++ b/test/transactionBatcher-test.js
@@ -12,8 +12,8 @@ const senderWallet1 = {
     sk: "c8a3c5333aa3b058c4fa16d48db52355ab62ddc8daa9a183706a912e522440b6"
 }
 const senderWallet2 = {
-    vk: "7d7427785b690cc5d2643d03fc58aedcd9c5574c25a08c03aee88f0e89b6c688",
-    sk: "1fd04104473c98594dc19ac3a8f370efc3ebe18bf6174a1458176706f148f782"
+    vk: "6a91a9a65eb80829a360efc0555cad8841af64c78375bbf394f6ecb89d5644ee",
+    sk: "4166ed44f465c51d562895295cdcde64a3444b14ea2a3e477c60cf0ecde65230"
 }
 
 let recieverWallet = {
@@ -169,7 +169,7 @@ describe('Test TransactionBuilder class', () => {
                 if (!txBuilder.txSendResult.hash) console.log(txBuilder.nonce + ": " + txBuilder.txSendResult.errors)
                 expect(typeof txBuilder.txSendResult.hash === 'string').to.be(true)
             })
-
+            console.log(txb)
             expect(txb.hasTransactions()).to.be(false)
         })
         it('Can process overflow', async function () {


### PR DESCRIPTION
checkForTransactionResult in TransactionBuilder would throw an error when the masternode returned an error string as opposed to the expected object.

I believe this is because this return result of being rate limited by cloudflare.

checkForTransactionResult now will check again in a second, in hopes of not being rate limited.