### PR TITLE
timedelta and datetime send objects instead of lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ const Lamden = require('lamden-js')
 
 ## Wallet Functions
 ### Create a Lamden Keypair
+Creates a new wallet object.
+- **verifying key (vk)**: public key
+- **secret key (sk)**: private key
 ```javascript
 let lamdenWallet = Lamden.wallet.new_wallet()
 
@@ -35,6 +38,7 @@ console.log(lamdenWallet)
 ```
 
 ### Get a public key (vk) from a private key (sk)
+Takes the sk as an argument and returns the vk
 ```javascript
 let sk = "69a8db3fb7196debc2711fad1fa1935918d09f5d8900d84c3288ea5237611c03"
 let vk = wallet.get_vk(sk)
@@ -44,6 +48,7 @@ console.log(vk)
 ```
 
 ### Sign a message
+Signs a string payload
 ```javascript
 const stringBuffer = Buffer.from('message')
 let messageBytes = new Uint8Array(stringBuffer);
@@ -56,6 +61,7 @@ console.log(signedMessage)
 ```
 
 #### Verify signature
+verify a payload
 ```javascript
 let validSignature = wallet.verify(vk, messageBytes, signedMessage)
 

--- a/con_values_testing.py
+++ b/con_values_testing.py
@@ -1,0 +1,21 @@
+yourState = Hash(default_value='')
+
+@export
+def test_values(UID: str, Str: str, Int: int, Float: float, Bool: bool, Dict: dict, List: list, ANY: Any, DateTime: datetime.datetime, TimeDelta: datetime.timedelta):
+    yourState[UID, 'Str'] = Str
+    assert isinstance(yourState[UID, 'Str'], str), 'Str should be of type str'
+    yourState[UID, 'Int'] = Int
+    assert isinstance(yourState[UID, 'Int'], int), 'Int should be of type int'
+    yourState[UID, 'Float'] = Float
+    #assert isinstance(yourState[UID, 'Float'], ContractingDecimal), type(yourState[UID, 'Float'])
+    yourState[UID, 'Bool'] = Bool
+    assert isinstance(yourState[UID, 'Bool'], bool), 'Bool should be of type bool'
+    yourState[UID, 'Dict'] = Dict
+    assert isinstance(yourState[UID, 'Dict'], dict), 'Dict should be of type dict'
+    yourState[UID, 'List'] = List
+    assert isinstance(yourState[UID, 'List'], list), 'List should be of type list'
+    yourState[UID, 'ANY'] = ANY
+    yourState[UID, 'DateTime'] = DateTime
+    assert isinstance(yourState[UID, 'DateTime'], datetime.datetime), 'DateTime should be of type DateTime'
+    yourState[UID, 'TimeDelta'] = TimeDelta
+    assert isinstance(yourState[UID, 'TimeDelta'], datetime.timedelta), 'TimeDelta should be of type TimeDelta'

--- a/dist/lamden.js
+++ b/dist/lamden.js
@@ -2392,10 +2392,10 @@ class EventEmitter {
     }
 
 /*
- *      bignumber.js v9.0.0
+ *      bignumber.js v9.0.1
  *      A JavaScript library for arbitrary-precision arithmetic.
  *      https://github.com/MikeMcl/bignumber.js
- *      Copyright (c) 2019 Michael Mclaughlin <M8ch88l@gmail.com>
+ *      Copyright (c) 2020 Michael Mclaughlin <M8ch88l@gmail.com>
  *      MIT Licensed.
  *
  *      BigNumber.prototype methods     |  BigNumber methods
@@ -4787,7 +4787,7 @@ function clone(configObject) {
       e = bitFloor((e + 1) / 2) - (e < 0 || e % 2);
 
       if (s == 1 / 0) {
-        n = '1e' + e;
+        n = '5e' + e;
       } else {
         n = s.toExponential();
         n = n.slice(0, n.indexOf('e') + 1) + e;
@@ -5355,7 +5355,7 @@ function Encoder (type, value) {
     const encodeDateTime = (val) => {
         val = !isDate(val) ? new Date(val) : val;
         if (!isDate(val)) throwError(val);
-        return [
+        return {'__time__': [
             val.getUTCFullYear(), 
             val.getUTCMonth(), 
             val.getUTCDate(), 
@@ -5363,13 +5363,13 @@ function Encoder (type, value) {
             val.getUTCMinutes(), 
             val.getUTCSeconds(), 
             val.getUTCMilliseconds()
-        ]
+        ]}
     };
     const encodeTimeDelta = (val) => {
         const time = isDate(val) ? val.getTime() : new Date(val).getTime();
         const days = parseInt(time  / 1000 / 60 / 60 / 24);
         const seconds = (time - (days * 24 * 60 * 60 * 1000)) / 1000;
-        return [days, seconds]
+        return {'__delta__':[days, seconds]}
     };
 
     const encodeList = (val) => {
@@ -5404,7 +5404,7 @@ function Encoder (type, value) {
 
     function parseObject (obj) {
         const encode = (k, v) => {
-            if (k === "datetime" || k === "datetime.datetime") return Encoder("datetime.datetime", v)
+            if (k === "datetime" || k === "datetime.datetime" ) return Encoder("datetime.datetime", v)
             if (k === "timedelta" || k === "datetime.timedelta") return Encoder("datetime.timedelta", v)
             if (k !== "__fixed__" && isFloat(v)) return encodeFloat(v)
             return v
@@ -5905,7 +5905,7 @@ class TransactionBuilder extends Network {
             //Set error if txSendResult doesn't exist
             if (response === 'undefined' || validateTypes$2.isStringWithValue(response)){
                 this.txSendResult.errors = ['TypeError: Failed to fetch'];
-            }else{
+            }else {
                 if (response.error) this.txSendResult.errors = [response.error];
                 else this.txSendResult = response;
             }
@@ -5925,31 +5925,31 @@ class TransactionBuilder extends Network {
                 if (typeof res === 'undefined'){
                     res = {};
                     res.error = 'TypeError: Failed to fetch';
-                }else{
+                }else {
                     if (typeof res === 'string') {
                         if (this.txCheckAttempts < this.txCheckLimit){
                             checkAgain = true;
-                        }else{
+                        }else {
                             this.txCheckResult.errors = [res];
                         }
-                    }else{
+                    }else {
                         if (res.error){
                             if (res.error === 'Transaction not found.'){
                                 if (this.txCheckAttempts < this.txCheckLimit){
                                     checkAgain = true;
-                                }else{
+                                }else {
                                     this.txCheckResult.errors = [res.error, `Retry Attmpts ${this.txCheckAttempts} hit while checking for Tx Result.`];
                                 }
-                            }else{
+                            }else {
                                 this.txCheckResult.errors = [res.error];
                             }
-                        }else{
+                        }else {
                             this.txCheckResult = res;
                         }
                     }
                 }
                 if (checkAgain) timerId = setTimeout(checkTx.bind(this), 1000);
-                else{
+                else {
                     if (validateTypes$2.isNumber(this.txCheckResult.status)){
                         if (this.txCheckResult.status > 0){
                             if (!validateTypes$2.isArray(this.txCheckResult.errors)) this.txCheckResult.errors = [];
@@ -5968,7 +5968,7 @@ class TransactionBuilder extends Network {
         if (validateTypes$2.isStringWithValue(result.hash) && validateTypes$2.isStringWithValue(result.success)){
             this.txHash = result.hash;
             this.setPendingBlockInfo();
-        }else{
+        }else {
             this.setBlockResultInfo(result);
             this.txBlockResult = result;
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lamden-js",
-  "version": "1.21.0",
+  "version": "1.3.0",
   "description": "A javascript implementaion for creating wallets, submitting transactions and interacting with masternodes on the Lamden Blockchain.",
   "main": "dist/lamden.js",
   "scripts": {

--- a/src/js/encoder.js
+++ b/src/js/encoder.js
@@ -68,7 +68,7 @@ function Encoder (type, value) {
     const encodeDateTime = (val) => {
         val = !isDate(val) ? new Date(val) : val
         if (!isDate(val)) throwError(val)
-        return [
+        return {'__time__': [
             val.getUTCFullYear(), 
             val.getUTCMonth(), 
             val.getUTCDate(), 
@@ -76,13 +76,13 @@ function Encoder (type, value) {
             val.getUTCMinutes(), 
             val.getUTCSeconds(), 
             val.getUTCMilliseconds()
-        ]
+        ]}
     }
     const encodeTimeDelta = (val) => {
         const time = isDate(val) ? val.getTime() : new Date(val).getTime()
         const days = parseInt(time  / 1000 / 60 / 60 / 24)
         const seconds = (time - (days * 24 * 60 * 60 * 1000)) / 1000
-        return [days, seconds]
+        return {'__delta__':[days, seconds]}
     }
 
     const encodeList = (val) => {
@@ -117,7 +117,7 @@ function Encoder (type, value) {
 
     function parseObject (obj) {
         const encode = (k, v) => {
-            if (k === "datetime" || k === "datetime.datetime") return Encoder("datetime.datetime", v)
+            if (k === "datetime" || k === "datetime.datetime" ) return Encoder("datetime.datetime", v)
             if (k === "timedelta" || k === "datetime.timedelta") return Encoder("datetime.timedelta", v)
             if (k !== "__fixed__" && isFloat(v)) return encodeFloat(v)
             return v

--- a/test/transactionBatcher-test.js
+++ b/test/transactionBatcher-test.js
@@ -132,7 +132,7 @@ describe('Test TransactionBuilder class', () => {
     })
     context('TransactionBatcher.sendBatch()', () => {
         it('can send a batch of successful transactions', async function () {
-            this.timeout(30000);
+            this.timeout(60000);
             let txb = new Lamden.TransactionBatcher(networkInfo)
             let response = await txb.getStartingNonce(senderWallet1.vk)
 
@@ -155,7 +155,7 @@ describe('Test TransactionBuilder class', () => {
 
     context('TransactionBatcher.sendAllBatches()', () => {
         it('Can send batches from all senders', async function () {
-            this.timeout(30000);
+            this.timeout(60000);
             sleep(1500)
             let txb = new Lamden.TransactionBatcher(networkInfo)
             const txList1 = makeTxList(senderWallet1.vk, recieverWallet.vk, 15)
@@ -169,7 +169,7 @@ describe('Test TransactionBuilder class', () => {
                 if (!txBuilder.txSendResult.hash) console.log(txBuilder.nonce + ": " + txBuilder.txSendResult.errors)
                 expect(typeof txBuilder.txSendResult.hash === 'string').to.be(true)
             })
-            console.log(txb)
+
             expect(txb.hasTransactions()).to.be(false)
         })
         it('Can process overflow', async function () {

--- a/test/transactionBuilder-test.js
+++ b/test/transactionBuilder-test.js
@@ -37,7 +37,7 @@ let kwargs = {
 
 let valuesTxInfo = {
     senderVk: senderWallet.vk,
-    contractName: 'con_values_testing',
+    contractName: 'con_values_testing_2',
     methodName: 'test_values',
     stampLimit: 100,
     kwargs: {
@@ -284,6 +284,7 @@ describe('Test TransactionBuilder class', () => {
 
             //Send Transaction
             let response = await newTx.send(senderWallet.sk);
+
             expect(response.success).to.be("Transaction successfully submitted to the network.")
             
             //Check Transaction


### PR DESCRIPTION
datetime and timedelta where originally sending arrays.
This was incorrect as contracting expects them to be __time__ and __delta__ objects respectively.

Updated Encoder to properly encode these data types. Updated tests cases for encoder to make sure datetime and timedelta are encoded when in lists and objects.

All tests pass.